### PR TITLE
Add Entity model and proxy it to normal model

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "invariant": "^2.2.1",
     "lodash": "^4.13.1",
+    "normalizr": "^2.2.1",
     "react-redux": "^4.4.5",
     "react-router": "^2.6.0",
     "react-router-redux": "^4.0.5",

--- a/src/feeble.js
+++ b/src/feeble.js
@@ -3,6 +3,7 @@ import { Provider } from 'react-redux'
 import model from './model'
 import createApiMiddleware from './middlewares/api'
 import createSagaMiddleware from './middlewares/saga'
+import Entity from './models/Entity'
 import createStore from './createStore'
 
 function feeble(options = {}) {
@@ -31,7 +32,7 @@ function feeble(options = {}) {
   }
 
   function addDefaultModels() {
-    // not default model currently
+    model(Entity)
   }
 
   function start() {
@@ -61,8 +62,8 @@ function feeble(options = {}) {
     return ext(_app)
   }
 
-  addDefaultMiddlewares()
   addDefaultModels()
+  addDefaultMiddlewares()
 
   Object.assign(_app, {
     middleware,

--- a/src/models/Entity.js
+++ b/src/models/Entity.js
@@ -1,0 +1,43 @@
+import feebleModel from '../model'
+import merge from 'lodash/fp/merge'
+import omit from 'lodash/fp/omit'
+import toArray from 'utils/toArray'
+
+const model = feebleModel({
+  namespace: 'entity',
+  state: {},
+})
+
+model.action('insert', (name, data) => ({ name, data }))
+model.action('update', (name, data) => ({ name, data }))
+model.action('drop', (name, ids) => ({ name, ids }))
+
+model.proxyActions = ['insert', 'update', 'drop']
+
+model.reducer(on => {
+  const pattern = action => action.payload && action.payload.entities
+  on(pattern, (state, payload) => merge(state, payload.entities))
+
+  on(model.insert, (state, payload) => ({
+    ...state,
+    [payload.name]: {
+      ...state[payload.name],
+      ...payload.data,
+    },
+  }))
+
+  on(model.update, (state, payload) => ({
+    ...state,
+    [payload.name]: {
+      ...state[payload.name],
+      ...payload.data,
+    },
+  }))
+
+  on(model.drop, (state, payload) => ({
+    ...state,
+    [payload.name]: omit(state[payload.name], toArray(payload.ids)),
+  }))
+})
+
+export default model

--- a/src/utils/toArray.js
+++ b/src/utils/toArray.js
@@ -1,0 +1,5 @@
+import flatten from 'lodash/fp/flatten'
+
+export default function toArray(v) {
+  return flatten([v])
+}

--- a/test/model.spec.js
+++ b/test/model.spec.js
@@ -18,6 +18,23 @@ test('create model', t => {
   t.is(counter.getNamespace(), 'counter')
 })
 
+// TODO: Add more tests
+test('create model with schema', t => {
+  const counter = model({
+    namespace: 'counter',
+    state: 0,
+    schema: {},
+    entityName: 'counter',
+  })
+
+  t.is(counter.getNamespace(), 'counter')
+  t.deepEqual(counter.schema, {})
+  t.deepEqual(counter.insert({ 1: 0 }), {
+    type: 'entity::insert',
+    payload: { name: 'counter', data: { 1: 0 } },
+  })
+})
+
 test('throw error for invalid namespace', t => {
   t.throws(
     () => { model({ namespace: 'foo1', state: 1 }) },


### PR DESCRIPTION
@yesmeck Do you like this approach to resolve #4 ?

如果你觉得这个 PR ok 的话，我可以列出代办列表，继续完善这个 PR，包括测试。
或者抽离出来，做一个 `feeble-entity` 可能更好？

我给 `Entity` 的 CRUD actions 起的名字是 `insert`, `drop`, 是因为我希望它看起来像是针对数据的操作。
